### PR TITLE
Remove redundant args

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -44,7 +44,6 @@ end
          optimiser,
          loss,
          epochs,
-         batch_size,
          lambda,
          alpha,
          verbosity,
@@ -76,7 +75,7 @@ instance `(X, y)` is
 where `l1 = sum(norm, params(chain)` and `l2 = sum(norm, params(chain))`.
 
 """
-function  fit!(chain, optimiser, loss, epochs, batch_size,
+function  fit!(chain, optimiser, loss, epochs,
                lambda, alpha, verbosity, data)
 
     Flux.testmode!(chain, false)

--- a/src/image.jl
+++ b/src/image.jl
@@ -37,8 +37,8 @@ function make_minibatch(X, Y, idxs)
 end
 
 # This will not only group into batches, but also convert to Flux compatible tensors
-function collate(model::ImageClassifier, X, Y, batch_size)
-    mb_idxs = partition(1:length(X), batch_size)
+function collate(model::ImageClassifier, X, Y)
+    mb_idxs = partition(1:length(X), model.batch_size)
     return [make_minibatch(X, Y, i) for i in mb_idxs]
 end
 
@@ -59,8 +59,7 @@ function MLJModelInterface.fit(model::ImageClassifier, verbosity::Int, X_, y_)
     optimiser = deepcopy(model.optimiser)
 
     chain, history = fit!(chain, optimiser, model.loss,
-        model.n, model.batch_size,
-        model.lambda, model.alpha,
+        model.n, model.lambda, model.alpha,
         verbosity, data)
 
     cache = deepcopy(model), data, history

--- a/test/core.jl
+++ b/test/core.jl
@@ -19,8 +19,8 @@ end
 
     y = rand(10)
     model = MLJFlux.NeuralNetworkRegressor()
-    batch_size= 3
-    @test MLJFlux.collate(model, X, y, batch_size) ==
+    model.batch_size= 3
+    @test MLJFlux.collate(model, X, y) ==
         [(Xmatrix'[:,1:3], y[1:3]),
          (Xmatrix'[:,4:6], y[4:6]),
          (Xmatrix'[:,7:9], y[7:9]),
@@ -30,14 +30,14 @@ end
     ymatrix = rand(10, 2)
     y = MLJBase.table(ymatrix) # a rowaccess table
     model = MLJFlux.NeuralNetworkRegressor()
-    batch_size= 3
-    @test MLJFlux.collate(model, X, y, batch_size) ==
+    model.batch_size= 3
+    @test MLJFlux.collate(model, X, y) ==
         [(Xmatrix'[:,1:3], ymatrix'[:,1:3]),
          (Xmatrix'[:,4:6], ymatrix'[:,4:6]),
          (Xmatrix'[:,7:9], ymatrix'[:,7:9]),
          (Xmatrix'[:,10:10], ymatrix'[:,10:10])]
     y = Tables.columntable(y) # try a columnaccess table
-    @test MLJFlux.collate(model, X, y, batch_size) ==
+    @test MLJFlux.collate(model, X, y) ==
         [(Xmatrix'[:,1:3], ymatrix'[:,1:3]),
          (Xmatrix'[:,4:6], ymatrix'[:,4:6]),
          (Xmatrix'[:,7:9], ymatrix'[:,7:9]),


### PR DESCRIPTION
Changes include:

1. Remove batch_size from fit!
2. Changed `collate(model, X, y, batch_size)` to `collate(model, X, y)`, since batch_size should be inferred from `model.batch_size`. (adding batch_size explicitly to collate was kind of redundant)