### PR TITLE
Builder <: MMI.Supervised

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -128,7 +128,7 @@ end
 # Below n or (n1, n2) etc refers to network inputs, while m or (m1,
 # m2) etc refers to outputs.
 
-abstract type Builder <: MLJModelInterface.Model end
+abstract type Builder <: MLJModelInterface.Supervised end
 
 # baby example 1:
 mutable struct Linear <: Builder


### PR DESCRIPTION
Wrapping a NeuralNetworkRegressor object in a machine gives me the error:
```
ERROR: MethodError: no method matching check(::MLJFlux.Short, ::Array{Float64,2}, ::Array{Float64,1})
Closest candidates are:
  check(::Supervised, ::Any...) at /Users/ayush99/.julia/packages/MLJBase/qJs1o/src/machines.jl:25
  check(::Unsupervised, ::Any...) at /Users/ayush99/.julia/packages/MLJBase/qJs1o/src/machines.jl:70
Stacktrace:
 [1] machine(::MLJFlux.Short, ::Array{Float64,2}, ::Array{Float64,1}) at /Users/ayush99/.julia/packages/MLJBase/qJs1o/src/machines.jl:92
 [2] top-level scope at REPL[5]:1
```

I think this is because `Builder <: MMI.Model`. Since all models here are Supervised, changing this to `Builder <: MMI.Supervised` fixes this issue.