### PR TITLE
Address dropout in post zygote revision

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ language: julia
 os:
   - linux
 julia:
-  - 1.0
-  - 1.1
-  - 1.2
+#  - 1.0
+#  - 1.1
+#  - 1.2
   - 1.3
+  - 1.4
   - nightly
 matrix:
   allow_failures:

--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ LossFunctions = "^0.5"
 MLJModelInterface = "^0.3"
 ProgressMeter = "^1.1"
 Tables = "^1.0"
-julia = "1"
+julia = "^1.3"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 CategoricalArrays = "^0.8.1"
-Flux = "^0.8.3"
+Flux = "^0.10.4"
 LossFunctions = "^0.5"
 MLJModelInterface = "^0.3"
 ProgressMeter = "^1.1"

--- a/src/classifier.jl
+++ b/src/classifier.jl
@@ -52,7 +52,7 @@ function MLJModelInterface.fit(model::NeuralNetworkClassifier,
 
     cache = (deepcopy(model), data, history, n_input, n_output)
     fitresult = (chain, levels)
-    report = (training_losses=[loss.data for loss in history], )
+    report = (training_losses=history, )
 
     return fitresult, cache, report
 end
@@ -62,7 +62,7 @@ function MLJModelInterface.predict(model::NeuralNetworkClassifier,
                                    Xnew_)
     chain, levels = fitresult
     Xnew = MLJModelInterface.matrix(Xnew_)
-    probs = vcat([chain(Xnew[i, :]).data' for i in 1:size(Xnew, 1)]...)
+    probs = vcat([chain(Xnew[i, :])' for i in 1:size(Xnew, 1)]...)
     return MLJModelInterface.UnivariateFinite(levels, probs)
 end
 
@@ -103,7 +103,7 @@ function MLJModelInterface.update(model::NeuralNetworkClassifier,
 
     fitresult = (chain, levels)
     cache = (deepcopy(model), data, history, n_input, n_output)
-    report = (training_losses=[loss.data for loss in history], )
+    report = (training_losses=history, )
 
     return fitresult, cache, report
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -78,7 +78,7 @@ where `l1 = sum(norm, params(chain)` and `l2 = sum(norm, params(chain))`.
 function  fit!(chain, optimiser, loss, epochs,
                lambda, alpha, verbosity, data)
 
-    Flux.testmode!(chain, false)
+    # Flux.testmode!(chain, false)
     # intitialize and start progress meter:
     meter = Progress(epochs+1, dt=0, desc="Optimising neural net:",
                      barglyphs=BarGlyphs("[=> ]"), barlen=25, color=:yellow)
@@ -107,7 +107,7 @@ function  fit!(chain, optimiser, loss, epochs,
         verbosity != 1 || next!(meter)
 
     end
-    Flux.testmode!(chain, true)         # to use in inference mode
+    # Flux.testmode!(chain, true)         # to use in inference mode
     return chain, history
 
 end

--- a/src/core.jl
+++ b/src/core.jl
@@ -92,7 +92,7 @@ function  fit!(chain, optimiser, loss, epochs,
         current_loss =
             mean(loss_func(data[i][1], data[i][2]) for i=1:length(data))
         verbosity < 2 ||
-            @info "Loss is $(round(current_loss.data; sigdigits=4))"
+            @info "Loss is $(round(current_loss; sigdigits=4))"
         push!(history, current_loss)
 
         # Early stopping is to be externally controlled.

--- a/src/image.jl
+++ b/src/image.jl
@@ -55,7 +55,7 @@ function MLJModelInterface.fit(model::ImageClassifier, verbosity::Int, X_, y_)
     cache = deepcopy(model), data, history, n_input, n_output
     fitresult = (chain, levels)
 
-    report = (training_losses=[loss.data for loss in history], )
+    report = (training_losses=history, )
 
     return fitresult, cache, report
 end
@@ -64,7 +64,7 @@ end
 function MLJModelInterface.predict(model::ImageClassifier, fitresult, Xnew)
     chain, levels = fitresult
     X = reformat(Xnew)
-    probs = vcat([chain(X[:,:,:,idx:idx]).data' for idx in 1:length(Xnew)]...)
+    probs = vcat([chain(X[:,:,:,idx:idx])' for idx in 1:length(Xnew)]...)
     return MLJModelInterface.UnivariateFinite(levels, probs)
 end
 
@@ -110,7 +110,7 @@ function MLJModelInterface.update(model::ImageClassifier,
 
     fitresult = (chain, levels)
     cache = (deepcopy(model), data, history, n_input, n_output)
-    report = (training_losses=[loss.data for loss in history], )
+    report = (training_losses=history, )
 
     return fitresult, cache, report
 

--- a/src/regressor.jl
+++ b/src/regressor.jl
@@ -84,7 +84,7 @@ function MLJModelInterface.fit(model::Regressor, verbosity::Int, X, y)
 
     cache = (deepcopy(model), data, history, n_input, n_output)
     fitresult = (chain, target_is_multivariate, target_column_names)
-    report = (training_losses=[loss.data for loss in history],)
+    report = (training_losses=history,)
 
     return fitresult, cache, report
 
@@ -125,7 +125,7 @@ function MLJModelInterface.update(model::Regressor,
     end
     fitresult = (chain, target_is_multivariate, target_column_names)
     cache = (deepcopy(model), data, history, n_input, n_output)
-    report = (training_losses=[loss.data for loss in history],)
+    report = (training_losses=history,)
 
     return fitresult, cache, report
 
@@ -138,12 +138,12 @@ function MLJModelInterface.predict(model::Regressor, fitresult, Xnew_)
     Xnew_ = MLJModelInterface.matrix(Xnew_)
 
     if target_is_multivariate
-        ypred = [map(x->x.data, chain(values.(Xnew_[i, :])))
+        ypred = [chain(values.(Xnew_[i, :]))
                  for i in 1:size(Xnew_, 1)]
         return MLJModelInterface.table(reduce(hcat, y for y in ypred)',
                                        names=target_column_names)
     else
-        return [chain(values.(Xnew_[i, :]))[1].data for i in 1:size(Xnew_, 1)]
+        return [chain(values.(Xnew_[i, :]))[1] for i in 1:size(Xnew_, 1)]
     end
 end
 

--- a/test/regressor.jl
+++ b/test/regressor.jl
@@ -28,7 +28,7 @@ end
               y,
               builder,
               optimiser,
-              0.7)
+              0.8)
 
     # test a bit better than constant predictor
     model = MLJFlux.MultitargetNeuralNetworkRegressor()


### PR DESCRIPTION
This PR is a continuation of #43 which:

- removes all `testmode!` toggling, leaving `Dropout` layers to be in `:auto` state by default (see https://github.com/FluxML/Flux.jl/blob/7a32a703f0f2842dda73d4454aff5990ade365d5/src/functor.jl#L42-L55). 

- modify/add tests to ensure that: 
    - chains with `Dropout` layers are deterministic (inactive) when called on data before and after `fit`
    - training with dropout layers with `p < 1` gives different outcome than training with `p=1` when initial weights are identical (the assumption being this implies the layers are stochastic (active) during training). 