### PR TITLE
Add GPU support, take 2

### DIFF
--- a/src/MLJFlux.jl
+++ b/src/MLJFlux.jl
@@ -1,7 +1,7 @@
 module MLJFlux
 
 import Flux
-import MLJModelInterface
+using MLJModelInterface
 using MLJModelInterface.ScientificTypes
 import Base.==
 using ProgressMeter
@@ -15,6 +15,7 @@ include("core.jl")
 include("regressor.jl")
 include("classifier.jl")
 include("image.jl")
+include("common.jl")
 
 ### Package specific model traits:
 MLJModelInterface.metadata_pkg.((NeuralNetworkRegressor,

--- a/src/classifier.jl
+++ b/src/classifier.jl
@@ -70,8 +70,8 @@ function MLJModelInterface.predict(model::NeuralNetworkClassifier,
                                    fitresult,
                                    Xnew_)
     chain, levels = fitresult
-    Xnew = MLJModelInterface.matrix(Xnew_)
-    probs = vcat([chain(Xnew[i, :])' for i in 1:size(Xnew, 1)]...)
+    Xnew = MLJModelInterface.matrix(Xnew_) |> Mover(model.acceleration)
+    probs = vcat([chain(Xnew[i, :])' for i in 1:size(Xnew, 1)]...) |> Flux.cpu
     return MLJModelInterface.UnivariateFinite(levels, probs)
 end
 

--- a/src/classifier.jl
+++ b/src/classifier.jl
@@ -49,9 +49,15 @@ function MLJModelInterface.fit(model::NeuralNetworkClassifier,
     data = collate(model, X, y)
     optimiser = deepcopy(model.optimiser)
 
-    chain, history = fit!(chain, optimiser, model.loss,
-                          model.epochs, model.lambda,
-                          model.alpha, verbosity, data, use_gpu(model.acceleration))
+    chain, history = fit!(chain,
+                          optimiser,
+                          model.loss,
+                          model.epochs,
+                          model.lambda,
+                          model.alpha,
+                          verbosity,
+                          data,
+                          model.acceleration)
 
     cache = (deepcopy(model), data, history, n_input, n_output)
     fitresult = (chain, levels)
@@ -97,9 +103,15 @@ function MLJModelInterface.update(model::NeuralNetworkClassifier,
 
     optimiser = deepcopy(model.optimiser)
 
-    chain, history = fit!(chain, optimiser, model.loss, epochs,
-                                model.lambda, model.alpha,
-                                verbosity, data, use_gpu(model.acceleration))
+    chain, history = fit!(chain,
+                          optimiser,
+                          model.loss,
+                          epochs,
+                          model.lambda,
+                          model.alpha,
+                          verbosity,
+                          data,
+                          model.acceleration)
     if keep_chain
         history = vcat(old_history, history)
     end

--- a/src/classifier.jl
+++ b/src/classifier.jl
@@ -78,8 +78,8 @@ function MLJModelInterface.predict(model::NeuralNetworkClassifier,
                                    fitresult,
                                    Xnew_)
     chain, levels = fitresult
-    Xnew = MLJModelInterface.matrix(Xnew_) |> Mover(model.acceleration)
-    probs = vcat([chain(Xnew[i, :])' for i in 1:size(Xnew, 1)]...) |> Flux.cpu
+    Xnew = MLJModelInterface.matrix(Xnew_) 
+    probs = vcat([chain(Xnew[i, :])' for i in 1:size(Xnew, 1)]...)
     return MLJModelInterface.UnivariateFinite(levels, probs)
 end
 

--- a/src/classifier.jl
+++ b/src/classifier.jl
@@ -113,7 +113,8 @@ function MLJModelInterface.update(model::NeuralNetworkClassifier,
                           data,
                           model.acceleration)
     if keep_chain
-        history = vcat(old_history, history)
+        # note: history[1] = old_history[end]
+        history = vcat(old_history[1:end-1], history)
     end
 
     fitresult = (chain, levels)

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,0 +1,29 @@
+MLJFluxModel = Union{NeuralNetworkRegressor,
+                     MultitargetNeuralNetworkRegressor,
+                     NeuralNetworkClassifier,
+                     ImageClassifier}
+
+function MLJModelInterface.clean!(model::MLJFluxModel)
+    warning = ""
+    if model.lambda < 0
+        warning *= "Need `lambda ≥ 0`. Resetting `lambda = 0`. "
+        model.lambda = 0
+    end
+    if model.alpha < 0 || model.alpha > 1
+        warning *= "Need alpha in the interval `[0, 1]`. Resetting `alpha = 0`. "
+        model.alpha = 0
+    end
+    if model.epochs < 0 
+        warning *= "Need `epochs ≥ 0`. Resetting `epochs = 10`. "
+        model.epochs = 10
+    end
+    if model.batch_size < 0 
+        warning *= "Need `batch_size ≥ 0`. Resetting `batch_size = 1`. "
+        model.batch_size = 1
+    end
+    if model.acceleration isa CUDALibs && gpu_isdead()
+        warning *= "`acceleration isa CUDALibs` "*
+            "but no CUDA device (GPU) currently live. "
+    end
+    return warning
+end

--- a/src/core.jl
+++ b/src/core.jl
@@ -102,9 +102,14 @@ function  fit!(chain, optimiser, loss, epochs,
     loss_func(x, y) = loss(chain(x), y)
     history = []
     prev_loss = Inf
-    if gpu
+    mode = if gpu
         data = Flux.gpu.(data)
         chain = Flux.gpu(chain)
+        "CUDALibs()"
+    else
+        data = Flux.cpu.(data)
+        chain = Flux.cpu(chain)
+        "CPU1()"
     end
 
     for i in 1:epochs
@@ -113,7 +118,7 @@ function  fit!(chain, optimiser, loss, epochs,
         current_loss =
             mean(loss_func(data[i][1], data[i][2]) for i=1:length(data))
         verbosity < 2 ||
-            @info "Loss is $(round(current_loss; sigdigits=4))"
+            @info "Loss is $(round(current_loss; sigdigits=4)) ($mode)"
         push!(history, current_loss)
 
         # Early stopping is to be externally controlled.

--- a/src/core.jl
+++ b/src/core.jl
@@ -39,8 +39,12 @@ end
 
 ## GENERAL METHOD TO OPTIMIZE A CHAIN
 
-move(data, ::CUDALibs) = Flux.gpu(data)
-move(data, ::CPU1) = Flux.cpu(data)
+struct Mover{R<:AbstractResource}
+    resource::R
+end
+
+(::Mover{<:CPU1})(data) = Flux.cpu(data)
+(::Mover{<:CUDALibs})(data) = Flux.gpu(data)
 
 """
     fit!(chain,
@@ -94,8 +98,9 @@ function  fit!(chain, optimiser, loss, epochs,
     loss_func(x, y) = loss(chain(x), y)
     history = []
     prev_loss = Inf
-    data = move(data, acceleration)
-    chain = move(chain, acceleration)
+    move = Mover(acceleration)
+    data = move(data)
+    chain = move(chain)
 
     for i in 1:epochs
         # We're taking data in a Flux-fashion.

--- a/src/core.jl
+++ b/src/core.jl
@@ -90,17 +90,20 @@ in `ComputationalResources.jl`.
 function  fit!(chain, optimiser, loss, epochs,
                lambda, alpha, verbosity, data, acceleration)
 
-    # Flux.testmode!(chain, false)
     # intitialize and start progress meter:
     meter = Progress(epochs+1, dt=0, desc="Optimising neural net:",
                      barglyphs=BarGlyphs("[=> ]"), barlen=25, color=:yellow)
     verbosity != 1 || next!(meter)
-    loss_func(x, y) = loss(chain(x), y)
-    history = []
-    prev_loss = Inf
+
     move = Mover(acceleration)
     data = move(data)
     chain = move(chain)
+
+    loss_func(x, y) = loss(chain(x), y)
+
+    # initiate history:
+    prev_loss = mean(loss_func(data[i][1], data[i][2]) for i=1:length(data))
+    history = [prev_loss,]
 
     for i in 1:epochs
         # We're taking data in a Flux-fashion.
@@ -123,7 +126,7 @@ function  fit!(chain, optimiser, loss, epochs,
         verbosity != 1 || next!(meter)
 
     end
-    # Flux.testmode!(chain, true)         # to use in inference mode
+    
     return chain, history
 
 end

--- a/src/core.jl
+++ b/src/core.jl
@@ -135,7 +135,7 @@ function  fit!(chain, optimiser, loss, epochs,
 
     end
     
-    return chain, history
+    return Flux.cpu(chain), history
 
 end
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -103,7 +103,6 @@ function  fit!(chain, optimiser, loss, epochs,
     history = []
     prev_loss = Inf
     if gpu
-        verbosity < 1 || @info "Using GPU for training"
         data = Flux.gpu.(data)
         chain = Flux.gpu(chain)
     end

--- a/src/core.jl
+++ b/src/core.jl
@@ -57,7 +57,7 @@ end
          alpha,
          verbosity,
          data,
-         gpu)
+         acceleration)
 
 Optimize a Flux model `chain` using the regularization parameters
 `lambda` (strength) and `alpha` (l2/l1 mix), where `loss(yhat, y) ` is
@@ -84,9 +84,15 @@ instance `(X, y)` is
 
 where `l1 = sum(norm, params(chain)` and `l2 = sum(norm, params(chain))`.
 
+One must have `acceleration isa CPU1` or `acceleration isa CUDALibs`
+where `CPU1` and `CUDALibs` are types defined in
+`ComputationalResources.jl`.
+
 """
 function  fit!(chain, optimiser, loss, epochs,
-               lambda, alpha, verbosity, data, gpu)
+               lambda, alpha, verbosity, data, acceleration)
+
+    gpu = use_gpu(acceleration)
 
     # Flux.testmode!(chain, false)
     # intitialize and start progress meter:

--- a/src/core.jl
+++ b/src/core.jl
@@ -118,7 +118,7 @@ function  fit!(chain, optimiser, loss, epochs,
         current_loss =
             mean(loss_func(data[i][1], data[i][2]) for i=1:length(data))
         verbosity < 2 ||
-            @info "Loss is $(round(current_loss; sigdigits=4)) ($mode)"
+            @info "Loss is $(round(current_loss; sigdigits=4))"
         push!(history, current_loss)
 
         # Early stopping is to be externally controlled.

--- a/src/image.jl
+++ b/src/image.jl
@@ -52,8 +52,15 @@ function MLJModelInterface.fit(model::ImageClassifier, verbosity::Int, X_, y_)
 
     optimiser = deepcopy(model.optimiser)
 
-    chain, history = fit!(chain, optimiser, model.loss,
-        model.epochs, model.lambda, model.alpha, verbosity, data, use_gpu(model.acceleration))
+    chain, history = fit!(chain,
+                          optimiser,
+                          model.loss,
+                          model.epochs,
+                          model.lambda,
+                          model.alpha,
+                          verbosity,
+                          data,
+                          model.acceleration)
 
     cache = deepcopy(model), data, history, n_input, n_output
     fitresult = (chain, levels)
@@ -104,9 +111,15 @@ function MLJModelInterface.update(model::ImageClassifier,
 
     optimiser = deepcopy(model.optimiser)
 
-    chain, history = fit!(chain, optimiser, model.loss, epochs,
-                                model.lambda, model.alpha,
-                                verbosity, data, use_gpu(model.acceleration))
+    chain, history = fit!(chain,
+                          optimiser,
+                          model.loss,
+                          epochs,
+                          model.lambda,
+                          model.alpha,
+                          verbosity,
+                          data,
+                          model.acceleration)
     if keep_chain
         history = vcat(old_history, history)
     end

--- a/src/image.jl
+++ b/src/image.jl
@@ -73,8 +73,9 @@ end
 # Xnew is an array of 3D values
 function MLJModelInterface.predict(model::ImageClassifier, fitresult, Xnew)
     chain, levels = fitresult
-    X = reformat(Xnew)
-    probs = vcat([chain(X[:,:,:,idx:idx])' for idx in 1:length(Xnew)]...)
+    X = reformat(Xnew) |> Mover(model.acceleration) 
+    probs = vcat([chain(X[:,:,:,idx:idx])'
+                  for idx in 1:length(Xnew)]...) |> Flux.cpu
     return MLJModelInterface.UnivariateFinite(levels, probs)
 end
 

--- a/src/image.jl
+++ b/src/image.jl
@@ -81,12 +81,11 @@ function MLJModelInterface.fit(model::ImageClassifier,
     return fitresult, cache, report
 end
 
-# Xnew is an array of 3D values
 function MLJModelInterface.predict(model::ImageClassifier, fitresult, Xnew)
     chain, levels = fitresult
-    X = reformat(Xnew) |> Mover(model.acceleration) 
+    X = reformat(Xnew) 
     probs = vcat([chain(X[:,:,:,idx:idx])'
-                  for idx in 1:length(Xnew)]...) |> Flux.cpu
+                  for idx in 1:length(Xnew)]...) 
     return MLJModelInterface.UnivariateFinite(levels, probs)
 end
 

--- a/src/image.jl
+++ b/src/image.jl
@@ -122,7 +122,8 @@ function MLJModelInterface.update(model::ImageClassifier,
                           data,
                           model.acceleration)
     if keep_chain
-        history = vcat(old_history, history)
+        # note: history[1] = old_history[end]
+        history = vcat(old_history[1:end-1], history)
     end
 
     fitresult = (chain, levels)

--- a/src/regressor.jl
+++ b/src/regressor.jl
@@ -139,7 +139,8 @@ function MLJModelInterface.update(model::Regressor,
                           data,
                           model.acceleration)
     if keep_chain
-        history = vcat(old_history, history)
+        # note: history[1] = old_history[end]
+        history = vcat(old_history[1:end-1], history)
     end
     fitresult = (chain, target_is_multivariate, target_column_names)
     cache = (deepcopy(model), data, history, n_input, n_output)

--- a/src/regressor.jl
+++ b/src/regressor.jl
@@ -84,9 +84,15 @@ function MLJModelInterface.fit(model::Regressor, verbosity::Int, X, y)
 
     optimiser = deepcopy(model.optimiser)
 
-    chain, history = fit!(chain, optimiser, model.loss,
-                          model.epochs, model.lambda, 
-                          model.alpha, verbosity, data, use_gpu(model.acceleration))
+    chain, history = fit!(chain,
+                          optimiser,
+                          model.loss,
+                          model.epochs,
+                          model.lambda,
+                          model.alpha,
+                          verbosity,
+                          data,
+                          model.acceleration)
 
     cache = (deepcopy(model), data, history, n_input, n_output)
     fitresult = (chain, target_is_multivariate, target_column_names)
@@ -123,9 +129,15 @@ function MLJModelInterface.update(model::Regressor,
 
     optimiser = deepcopy(model.optimiser)
 
-    chain, history = fit!(chain, optimiser, model.loss, epochs,
-                                model.lambda, model.alpha,
-                                verbosity, data, use_gpu(model.acceleration))
+    chain, history = fit!(chain,
+                          optimiser,
+                          model.loss,
+                          epochs,
+                          model.lambda,
+                          model.alpha,
+                          verbosity,
+                          data,
+                          model.acceleration)
     if keep_chain
         history = vcat(old_history, history)
     end

--- a/src/regressor.jl
+++ b/src/regressor.jl
@@ -153,15 +153,16 @@ function MLJModelInterface.predict(model::Regressor, fitresult, Xnew_)
 
     chain , target_is_multivariate, target_column_names = fitresult
 
-    Xnew_ = MLJModelInterface.matrix(Xnew_)
+    Xnew_ = MLJModelInterface.matrix(Xnew_) |> Mover(model.acceleration)
 
     if target_is_multivariate
         ypred = [chain(values.(Xnew_[i, :]))
-                 for i in 1:size(Xnew_, 1)]
+                 for i in 1:size(Xnew_, 1)] |> Flux.cpu
         return MLJModelInterface.table(reduce(hcat, y for y in ypred)',
                                        names=target_column_names)
     else
-        return [chain(values.(Xnew_[i, :]))[1] for i in 1:size(Xnew_, 1)]
+        return [chain(values.(Xnew_[i, :]))[1]
+                for i in 1:size(Xnew_, 1)] |> Flux.cpu
     end
 end
 

--- a/src/regressor.jl
+++ b/src/regressor.jl
@@ -167,16 +167,16 @@ function MLJModelInterface.predict(model::Regressor, fitresult, Xnew_)
 
     chain , target_is_multivariate, target_column_names = fitresult
 
-    Xnew_ = MLJModelInterface.matrix(Xnew_) |> Mover(model.acceleration)
+    Xnew_ = MLJModelInterface.matrix(Xnew_) 
 
     if target_is_multivariate
         ypred = [chain(values.(Xnew_[i, :]))
-                 for i in 1:size(Xnew_, 1)] |> Flux.cpu
+                 for i in 1:size(Xnew_, 1)] 
         return MLJModelInterface.table(reduce(hcat, y for y in ypred)',
                                        names=target_column_names)
     else
         return [chain(values.(Xnew_[i, :]))[1]
-                for i in 1:size(Xnew_, 1)] |> Flux.cpu
+                for i in 1:size(Xnew_, 1)] 
     end
 end
 

--- a/test/_gpu_benchmarking.jl
+++ b/test/_gpu_benchmarking.jl
@@ -33,13 +33,17 @@ basedir = joinpath(dirname(pathof(MLJFlux)), "..", "test")
 include(joinpath(basedir, "test_utils.jl"))
 
 # CPU
-model = MLJFlux.ImageClassifier(builder=MyConvBuilder(), acceleration=CPU1())
+model = MLJFlux.ImageClassifier(builder=MyConvBuilder(),
+                                batch_size=50,
+                                acceleration=CPU1());
 @btime MLJBase.fit($model, 0, $images, $labels);
-# 16.877 s (7401673 allocations: 8.15 GiB)
+# 16.877 s (7401673 allocations: 8.15 GiB) batch_size = 1 
+#  8.816 s (409635 allocations: 3.15 GiB) batch_size = 50
 
 # GPU
 model.acceleration = CUDALibs()
 @btime MLJBase.fit($model, 0, $images, $labels);
-# 30.214 s (46970158 allocations: 2.37 GiB)
+# 30.214 s (46970158 allocations: 2.37 GiB) batch_size = 1
+# 600.534 ms (960560 allocations: 52.82 MiB) batch_size = 50
 
 

--- a/test/_gpu_benchmarking.jl
+++ b/test/_gpu_benchmarking.jl
@@ -1,0 +1,45 @@
+# This stand-alone file is for benchmarking CPU/GPU on MNIST dataset
+
+using MLJFlux, BenchmarkTools, Flux, ComputationalResources
+
+mutable struct MyConvBuilder <: MLJFlux.Builder end
+
+using Flux.Data:MNIST
+
+N = 500
+images, labels = MNIST.images()[1:N], MNIST.labels()[1:N];
+
+labels = categorical(labels);
+
+function flatten(x::AbstractArray)
+    return reshape(x, :, size(x)[end])
+end
+
+function MLJFlux.build(builder::MyConvBuilder, n_in, n_out, n_channels)
+    cnn_output_size = [3,3,32]
+
+    return Chain(
+        Conv((3, 3), n_channels=>16, pad=(1,1), relu),
+        MaxPool((2,2)),
+        Conv((3, 3), 16=>32, pad=(1,1), relu),
+        MaxPool((2,2)),
+        Conv((3, 3), 32=>32, pad=(1,1), relu),
+        MaxPool((2,2)),
+        flatten,
+        Dense(prod(cnn_output_size), n_out))
+end
+
+basedir = joinpath(dirname(pathof(MLJFlux)), "..", "test")
+include(joinpath(basedir, "test_utils.jl"))
+
+# CPU
+model = MLJFlux.ImageClassifier(builder=MyConvBuilder(), acceleration=CPU1())
+@btime MLJBase.fit($model, 0, $images, $labels);
+# 16.877 s (7401673 allocations: 8.15 GiB)
+
+# GPU
+model.acceleration = CUDALibs()
+@btime MLJBase.fit($model, 0, $images, $labels);
+# 30.214 s (46970158 allocations: 2.37 GiB)
+
+

--- a/test/classifier.jl
+++ b/test/classifier.jl
@@ -1,28 +1,34 @@
 ## NEURAL NETWORK CLASSIFIER
 
-@testset "NeuralNetworkClassifier" begin
-    seed!(1234)
-    N = 300
-    X = MLJBase.table(rand(Float32, N, 4));
-    ycont = 2*X.x1 - X.x3 + 0.1*rand(N)
-    m, M = minimum(ycont), maximum(ycont)
-    _, a, b, _ = range(m, stop=M, length=4) |> collect
-    y = map(ycont) do η
-        if η < 0.9*a
-            :a
-        elseif η < 1.1*b
-            :b
-        else
-            :c
-        end
-    end |> categorical;
+seed!(1234)
+N = 300
+X = MLJBase.table(rand(Float32, N, 4));
+ycont = 2*X.x1 - X.x3 + 0.1*rand(N)
+m, M = minimum(ycont), maximum(ycont)
+_, a, b, _ = range(m, stop=M, length=4) |> collect
+y = map(ycont) do η
+    if η < 0.9*a
+        :a
+    elseif η < 1.1*b
+        :b
+    else
+        :c
+    end
+end |> categorical;
 
-    builder = MLJFlux.Short()
-    optimiser = Flux.Optimise.ADAM(0.01)
+builder = MLJFlux.Short()
+optimiser = Flux.Optimise.ADAM(0.01)
 
-    optimiser = Flux.Optimise.ADAM(0.01)
+optimiser = Flux.Optimise.ADAM(0.01)
 
-    basictest(MLJFlux.NeuralNetworkClassifier, X, y, builder, optimiser, 0.75)
+@testset_accelerated "NeuralNetworkClassifier" accel begin
+    basictest(MLJFlux.NeuralNetworkClassifier,
+              X,
+              y,
+              builder,
+              optimiser,
+              0.75,
+              accel)
 
     train, test = MLJBase.partition(1:N, 0.7)
 
@@ -38,39 +44,10 @@
 
     # check flux model is an improvement on predicting constant
     # distribution:
-    model = MLJFlux.NeuralNetworkClassifier(epochs=150)
+    model = MLJFlux.NeuralNetworkClassifier(epochs=150, acceleration=accel)
     mach = fit!(machine(model, X, y), rows=train, verbosity=0)
     yhat = MLJBase.predict(mach, rows=test);
     @test mean(MLJBase.cross_entropy(yhat, y[test])) < 0.9*loss_baseline
 end
-
-
-## OLD CLASSIFIER TEST
-
-# train = 1:7N
-# test = (7N+1):10N
-
-
-# builder = MLJFlux.Linear(σ=Flux.sigmoid)
-# model = MLJFlux.NeuralNetworkClassifier(loss=Flux.crossentropy,
-#                                         builder=builder)
-
-# fitresult, cache, report =
-#     MLJBase.fit(model, 2, MLJBase.selectrows(X,train), y[train])
-
-# yhat = MLJBase.predict(model, fitresult, MLJBase.selectrows(X, test))
-
-# # Update without completely retraining
-# model.epochs = 15
-# fitresult, cache, report =
-#     MLJBase.update(model, 2, fitresult, cache,
-#                    MLJBase.selectrows(X,train), y[train])
-
-# # Update by completely retraining
-# model.batch_size = 5
-# fitresult, cache, report =
-#     MLJBase.update(model, 3, fitresult, cache,
-#                    MLJBase.selectrows(X,train), y[train])
-
 
 true

--- a/test/classifier.jl
+++ b/test/classifier.jl
@@ -16,9 +16,9 @@ y = map(ycont) do η
     end
 end |> categorical;
 
-builder = MLJFlux.Short()
-optimiser = Flux.Optimise.ADAM(0.01)
-
+# TODO: replace Short2 -> Short when
+# https://github.com/FluxML/Flux.jl/issues/1372 is resolved:
+builder = Short2()
 optimiser = Flux.Optimise.ADAM(0.01)
 
 @testset_accelerated "NeuralNetworkClassifier" accel begin
@@ -46,7 +46,9 @@ optimiser = Flux.Optimise.ADAM(0.01)
     # check flux model is an improvement on predicting constant
     # distribution:
     model = MLJFlux.NeuralNetworkClassifier(epochs=150, acceleration=accel)
-    @time mach = fit!(machine(model, X, y), rows=train, verbosity=2)
+    @time mach = fit!(machine(model, X, y), rows=train, verbosity=0)
+    first_last_training_loss = MLJBase.report(mach)[1][[1, end]]
+    @show first_last_training_loss
     yhat = MLJBase.predict(mach, rows=test);
     @test mean(MLJBase.cross_entropy(yhat, y[test])) < 0.9*loss_baseline
 end

--- a/test/classifier.jl
+++ b/test/classifier.jl
@@ -61,7 +61,6 @@ end
 
 # check different resources (CPU1, CUDALibs, etc)) give about the same loss:
 reference = losses[1]
-abs(losses[2] - reference)/reference
 @test all(x->abs(x - reference)/reference < 1e-5, losses[2:end])
 
 true

--- a/test/classifier.jl
+++ b/test/classifier.jl
@@ -28,7 +28,7 @@ optimiser = Flux.Optimise.ADAM(0.01)
               y,
               builder,
               optimiser,
-              0.75,
+              0.85,
               accel)
 
     train, test = MLJBase.partition(1:N, 0.7)
@@ -46,7 +46,7 @@ optimiser = Flux.Optimise.ADAM(0.01)
     # check flux model is an improvement on predicting constant
     # distribution:
     model = MLJFlux.NeuralNetworkClassifier(epochs=150, acceleration=accel)
-    mach = fit!(machine(model, X, y), rows=train, verbosity=0)
+    @time mach = fit!(machine(model, X, y), rows=train, verbosity=2)
     yhat = MLJBase.predict(mach, rows=test);
     @test mean(MLJBase.cross_entropy(yhat, y[test])) < 0.9*loss_baseline
 end

--- a/test/classifier.jl
+++ b/test/classifier.jl
@@ -22,6 +22,7 @@ optimiser = Flux.Optimise.ADAM(0.01)
 optimiser = Flux.Optimise.ADAM(0.01)
 
 @testset_accelerated "NeuralNetworkClassifier" accel begin
+    Random.seed!(123)
     basictest(MLJFlux.NeuralNetworkClassifier,
               X,
               y,

--- a/test/classifier.jl
+++ b/test/classifier.jl
@@ -19,7 +19,9 @@ end |> categorical;
 # TODO: replace Short2 -> Short when
 # https://github.com/FluxML/Flux.jl/issues/1372 is resolved:
 builder = Short2()
-optimiser = Flux.Optimise.ADAM(0.01)
+optimiser = Flux.Optimise.ADAM(0.03)
+
+losses = []
 
 @testset_accelerated "NeuralNetworkClassifier" accel begin
     Random.seed!(123)
@@ -45,12 +47,21 @@ optimiser = Flux.Optimise.ADAM(0.01)
 
     # check flux model is an improvement on predicting constant
     # distribution:
-    model = MLJFlux.NeuralNetworkClassifier(epochs=150, acceleration=accel)
+    model = MLJFlux.NeuralNetworkClassifier(epochs=50,
+                                            builder=builder,
+                                            optimiser=optimiser,
+                                            acceleration=accel,
+                                            batch_size=10)
     @time mach = fit!(machine(model, X, y), rows=train, verbosity=0)
     first_last_training_loss = MLJBase.report(mach)[1][[1, end]]
-    @show first_last_training_loss
+    push!(losses, first_last_training_loss[2])
     yhat = MLJBase.predict(mach, rows=test);
-    @test mean(MLJBase.cross_entropy(yhat, y[test])) < 0.9*loss_baseline
+    @test mean(MLJBase.cross_entropy(yhat, y[test])) < 0.95*loss_baseline
 end
+
+# check different resources (CPU1, CUDALibs, etc)) give about the same loss:
+reference = losses[1]
+abs(losses[2] - reference)/reference
+@test all(x->abs(x - reference)/reference < 1e-5, losses[2:end])
 
 true

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,0 +1,30 @@
+ModelType = MLJFlux.NeuralNetworkRegressor
+
+@testset "clean!" begin
+    model = @test_logs (:warn, r"`lambda") begin
+        ModelType(lambda = -1)
+    end
+    @test model.lambda == 0
+
+    model = @test_logs (:warn, r"`alpha") begin
+        ModelType(alpha = -1)
+    end
+    @test model.alpha == 0
+
+    model = @test_logs (:warn, r"`epochs") begin
+        ModelType(epochs = -1)
+    end
+    @test model.epochs == 10
+    
+    model = @test_logs (:warn, r"`batch_size") begin
+        ModelType(batch_size = -1)
+    end
+    @test model.batch_size == 1
+    
+    if MLJFlux.gpu_isdead()
+        model  = @test_logs (:warn, r"`acceleration") begin
+            ModelType(acceleration=CUDALibs())
+        end
+        @test model.acceleration == CUDALibs()
+    end
+end

--- a/test/core.jl
+++ b/test/core.jl
@@ -99,12 +99,17 @@ chain_yes_drop = Flux.Chain(Flux.Dense(5, 15),
 chain_no_drop = deepcopy(chain_yes_drop)
 chain_no_drop.layers[2].p = 1.0
 
-test_input = rand(5, 1)
+test_input = rand(Float32, 5, 1)
 
 # check both chains have same behaviour before training:
 @test chain_yes_drop(test_input) == chain_no_drop(test_input)
 
+move(data, ::CUDALibs) = Flux.gpu(data)
+move(data, ::Any) = Flux.cpu(data)
+
 @testset_accelerated "fit! and dropout" accel begin
+
+    test_input = move(rand(Float32, 5, 1), accel)
 
     Random.seed!(123)
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -31,7 +31,7 @@ end
     # NeuralNetworClassifier:
     y = categorical([:a, :b, :a, :a, :b, :a, :a, :a, :b, :a])
     model = MLJFlux.NeuralNetworkClassifier()
-    model.batch_size= 3
+    model.batch_size = 3
     data = MLJFlux.collate(model, X, y)
     @test first.(data) ==
         [Xmatrix'[:,1:3], Xmatrix'[:,4:6],
@@ -104,13 +104,12 @@ test_input = rand(Float32, 5, 1)
 # check both chains have same behaviour before training:
 @test chain_yes_drop(test_input) == chain_no_drop(test_input)
 
-move(data, ::CUDALibs) = Flux.gpu(data)
-move(data, ::Any) = Flux.cpu(data)
 epochs = 10
 
 @testset_accelerated "fit! and dropout" accel begin
 
-    test_input = move(rand(Float32, 5, 1), accel)
+    move = MLJFlux.Mover(accel)
+    test_input = move(rand(Float32, 5, 1))
 
     Random.seed!(123)
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,3 +1,5 @@
+Random.seed!(123)
+
 @testset "optimiser equality" begin
     @test Flux.Momentum() == Flux.Momentum()
     @test Flux.Momentum(0.1) != Flux.Momentum(0.2)
@@ -103,6 +105,8 @@ test_input = rand(5, 1)
 @test chain_yes_drop(test_input) == chain_no_drop(test_input)
 
 @testset_accelerated "fit! and dropout" accel begin
+
+    Random.seed!(123)
 
     _chain_yes_drop, history = MLJFlux.fit!(chain_yes_drop,
                                   Flux.Optimise.ADAM(0.001),

--- a/test/core.jl
+++ b/test/core.jl
@@ -109,12 +109,16 @@ test_input = rand(5, 1)
     Random.seed!(123)
 
     _chain_yes_drop, history = MLJFlux.fit!(chain_yes_drop,
-                                  Flux.Optimise.ADAM(0.001),
-                                  Flux.mse, 10, 0, 0, 3, data, accel)
+                                            Flux.Optimise.ADAM(0.001),
+                                            Flux.mse, 10, 0, 0, 3, data, accel)
+    
+    println()
+    
+    Random.seed!(123)
 
     _chain_no_drop, history = MLJFlux.fit!(chain_no_drop,
-                                  Flux.Optimise.ADAM(0.001),
-                                  Flux.mse, 10, 0, 0, 3, data, accel)
+                                           Flux.Optimise.ADAM(0.001),
+                                           Flux.mse, 10, 0, 0, 3, data, accel)
 
     # check chains have different behaviour after training:
     @test !(_chain_yes_drop(test_input) ≈ _chain_no_drop(test_input))

--- a/test/core.jl
+++ b/test/core.jl
@@ -109,7 +109,6 @@ epochs = 10
 @testset_accelerated "fit! and dropout" accel begin
 
     move = MLJFlux.Mover(accel)
-    test_input = move(rand(Float32, 5, 1))
 
     Random.seed!(123)
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -106,6 +106,7 @@ test_input = rand(Float32, 5, 1)
 
 move(data, ::CUDALibs) = Flux.gpu(data)
 move(data, ::Any) = Flux.cpu(data)
+epochs = 10
 
 @testset_accelerated "fit! and dropout" accel begin
 
@@ -115,7 +116,7 @@ move(data, ::Any) = Flux.cpu(data)
 
     _chain_yes_drop, history = MLJFlux.fit!(chain_yes_drop,
                                             Flux.Optimise.ADAM(0.001),
-                                            Flux.mse, 10, 0, 0, 3, data, accel)
+                                            Flux.mse, epochs, 0, 0, 0, data, accel)
     
     println()
     
@@ -123,7 +124,7 @@ move(data, ::Any) = Flux.cpu(data)
 
     _chain_no_drop, history = MLJFlux.fit!(chain_no_drop,
                                            Flux.Optimise.ADAM(0.001),
-                                           Flux.mse, 10, 0, 0, 3, data, accel)
+                                           Flux.mse, epochs, 0, 0, 0, data, accel)
 
     # check chains have different behaviour after training:
     @test !(_chain_yes_drop(test_input) ≈ _chain_no_drop(test_input))
@@ -133,7 +134,7 @@ move(data, ::Any) = Flux.cpu(data)
     @test all(_chain_yes_drop(test_input) ==
               _chain_yes_drop(test_input) for i in 1:1000)
 
-    @test length(history) == 10
+    @test length(history) == epochs + 1
 
 end
 

--- a/test/image.jl
+++ b/test/image.jl
@@ -32,19 +32,21 @@ labels = categorical(rand(1:5, 50));
                                     epochs=10,
                                     acceleration=accel)
 
-    fitresult, cache, report = MLJBase.fit(model, 3, images, labels)
+    fitresult, cache, _report = MLJBase.fit(model, 0, images, labels)
 
     pred = MLJBase.predict(model, fitresult, images[1:6])
 
     model.epochs = 15
-    MLJBase.update(model, 3, fitresult, cache, images, labels)
+    MLJBase.update(model, 0, fitresult, cache, images, labels)
 
     pred = MLJBase.predict(model, fitresult, images[1:6])
 
     # try with batch_size > 1:
     model = MLJFlux.ImageClassifier(builder=builder, epochs=10, batch_size=2,
                                     acceleration=accel)
-    @time fitresult, cache, report = MLJBase.fit(model, 3, images, labels);
+    @time fitresult, cache, _report = MLJBase.fit(model, 0, images, labels);
+    first_last_training_loss = _report[1][[1, end]]
+    @show first_last_training_loss
 
     # tests update logic, etc (see test_utililites.jl):
     @test basictest(MLJFlux.ImageClassifier, images, labels,
@@ -87,8 +89,10 @@ end
 
     model = MLJFlux.ImageClassifier(builder=MyConvBuilder(), acceleration=accel)
 
-    @time fitresult, cache, report =
-        MLJBase.fit(model, 3, images[1:500], labels[1:500]);
+    @time fitresult, cache, _report =
+        MLJBase.fit(model, 0, images[1:500], labels[1:500]);
+    first_last_training_loss = _report[1][[1, end]]
+    @show first_last_training_loss
 
     pred = mode.(MLJBase.predict(model, fitresult, images[501:600]));
     error = misclassification_rate(pred, labels[501:600])
@@ -115,22 +119,19 @@ labels = categorical(rand(1:5, 50));
 
     model = MLJFlux.ImageClassifier(builder=builder, epochs=10, acceleration=accel)
 
-    fitresult, cache, report = MLJBase.fit(model, 3, images, labels)
-
-    pred = MLJBase.predict(model, fitresult, images[1:6])
-
-    model.epochs = 15
-    MLJBase.update(model, 3, fitresult, cache, images, labels)
-
-    pred = MLJBase.predict(model, fitresult, images[1:6])
-
-    # try with batch_size > 1:
-    model = MLJFlux.ImageClassifier(builder=builder, epochs=10, batch_size=2, acceleration=accel)
-    @time fitresult, cache, report = MLJBase.fit(model, 3, images, labels);
-
     # tests update logic, etc (see test_utililites.jl):
     @test basictest(MLJFlux.ImageClassifier, images, labels,
                            model.builder, model.optimiser, 0.95, accel)
+    
+    @time fitresult, cache, _report = MLJBase.fit(model, 0, images, labels)
+    pred = MLJBase.predict(model, fitresult, images[1:6])
+    first_last_training_loss = _report[1][[1, end]]
+    @show first_last_training_loss
+
+    # try with batch_size > 1:
+    model = MLJFlux.ImageClassifier(builder=builder, epochs=10, batch_size=2, acceleration=accel)
+    fitresult, cache, _report = MLJBase.fit(model, 0, images, labels);
+
 end
 
 true

--- a/test/image.jl
+++ b/test/image.jl
@@ -1,5 +1,7 @@
 ## BASIC IMAGE TESTS GREY
 
+Random.seed!(123)
+
 mutable struct mynn <: MLJFlux.Builder
     kernel1
     kernel2
@@ -23,6 +25,8 @@ images = coerce(raw_images, GrayImage);
 labels = categorical(rand(1:5, 50));
 
 @testset_accelerated "ImageClassifier basic tests" accel begin
+
+    Random.seed!(123)
 
     model = MLJFlux.ImageClassifier(builder=builder,
                                     epochs=10,
@@ -78,6 +82,8 @@ end
 
 @testset_accelerated "Image MNIST" accel begin
 
+    Random.seed!(123)
+
     model = MLJFlux.ImageClassifier(builder=MyConvBuilder())
 
     fitresult, cache, report =
@@ -103,6 +109,8 @@ images = coerce(raw_images, ColorImage);
 labels = categorical(rand(1:5, 50));
 
 @testset_accelerated "ColorImages" accel begin
+
+    Random.seed!(123)
 
     model = MLJFlux.ImageClassifier(builder=builder, epochs=10)
 

--- a/test/image.jl
+++ b/test/image.jl
@@ -42,8 +42,9 @@ labels = categorical(rand(1:5, 50));
     pred = MLJBase.predict(model, fitresult, images[1:6])
 
     # try with batch_size > 1:
-    model = MLJFlux.ImageClassifier(builder=builder, epochs=10, batch_size=2)
-    fitresult, cache, report = MLJBase.fit(model, 3, images, labels);
+    model = MLJFlux.ImageClassifier(builder=builder, epochs=10, batch_size=2,
+                                    acceleration=accel)
+    @time fitresult, cache, report = MLJBase.fit(model, 3, images, labels);
 
     # tests update logic, etc (see test_utililites.jl):
     @test basictest(MLJFlux.ImageClassifier, images, labels,
@@ -84,9 +85,9 @@ end
 
     Random.seed!(123)
 
-    model = MLJFlux.ImageClassifier(builder=MyConvBuilder())
+    model = MLJFlux.ImageClassifier(builder=MyConvBuilder(), acceleration=accel)
 
-    fitresult, cache, report =
+    @time fitresult, cache, report =
         MLJBase.fit(model, 3, images[1:500], labels[1:500]);
 
     pred = mode.(MLJBase.predict(model, fitresult, images[501:600]));
@@ -112,7 +113,7 @@ labels = categorical(rand(1:5, 50));
 
     Random.seed!(123)
 
-    model = MLJFlux.ImageClassifier(builder=builder, epochs=10)
+    model = MLJFlux.ImageClassifier(builder=builder, epochs=10, acceleration=accel)
 
     fitresult, cache, report = MLJBase.fit(model, 3, images, labels)
 
@@ -124,8 +125,8 @@ labels = categorical(rand(1:5, 50));
     pred = MLJBase.predict(model, fitresult, images[1:6])
 
     # try with batch_size > 1:
-    model = MLJFlux.ImageClassifier(builder=builder, epochs=10, batch_size=2)
-    fitresult, cache, report = MLJBase.fit(model, 3, images, labels);
+    model = MLJFlux.ImageClassifier(builder=builder, epochs=10, batch_size=2, acceleration=accel)
+    @time fitresult, cache, report = MLJBase.fit(model, 3, images, labels);
 
     # tests update logic, etc (see test_utililites.jl):
     @test basictest(MLJFlux.ImageClassifier, images, labels,

--- a/test/image.jl
+++ b/test/image.jl
@@ -1,3 +1,5 @@
+## BASIC IMAGE TESTS GREY
+
 mutable struct mynn <: MLJFlux.Builder
     kernel1
     kernel2
@@ -9,19 +11,22 @@ MLJFlux.build(model::mynn, ip, op, n_channels) =
                    x->reshape(x, :, size(x)[end]),
                    Flux.Dense(16, op))
 
-@testset "ImageClassifier" begin
+builder = mynn((2,2), (2,2))
 
-    builder = mynn((2,2), (2,2))
-    model = MLJFlux.ImageClassifier(builder=builder, epochs=10)
+# collection of gray images as a 4D array in WHCN format:
+raw_images = rand(Float32, 6, 6, 1, 50);
 
-    # collection of gray images as a 4D array in WHCN format:
-    raw_images = rand(6, 6, 1, 50);
+# as a vector of Matrix{<:AbstractRGB}
+images = coerce(raw_images, GrayImage);
+@test scitype(images) == AbstractVector{GrayImage{6,6}}
 
-    # as a vector of Matrix{<:AbstractRGB}
-    images = coerce(raw_images, GrayImage);
-    @test scitype(images) == AbstractVector{GrayImage{6,6}}
+labels = categorical(rand(1:5, 50));
 
-    labels = categorical(rand(1:5, 50));
+@testset_accelerated "ImageClassifier basic tests" accel begin
+
+    model = MLJFlux.ImageClassifier(builder=builder,
+                                    epochs=10,
+                                    acceleration=accel)
 
     fitresult, cache, report = MLJBase.fit(model, 3, images, labels)
 
@@ -38,36 +43,40 @@ MLJFlux.build(model::mynn, ip, op, n_channels) =
 
     # tests update logic, etc (see test_utililites.jl):
     @test basictest(MLJFlux.ImageClassifier, images, labels,
-                           model.builder, model.optimiser, 0.95)
+                           model.builder, model.optimiser, 0.95, accel)
 
 end
 
+
+## MNIST IMAGES TEST
+
 mutable struct MyConvBuilder <: MLJFlux.Builder end
 
-@testset "Image MNIST" begin
-    using Flux.Data:MNIST
+using Flux.Data:MNIST
 
-    images, labels = MNIST.images(), MNIST.labels();
+images, labels = MNIST.images(), MNIST.labels();
 
-    labels = categorical(labels);
+labels = categorical(labels);
 
-    function flatten(x::AbstractArray)
-        return reshape(x, :, size(x)[end])
-    end
+function flatten(x::AbstractArray)
+    return reshape(x, :, size(x)[end])
+end
 
-    function MLJFlux.build(builder::MyConvBuilder, n_in, n_out, n_channels)
-        cnn_output_size = [3,3,32]
+function MLJFlux.build(builder::MyConvBuilder, n_in, n_out, n_channels)
+    cnn_output_size = [3,3,32]
 
-        return Chain(
-            Conv((3, 3), n_channels=>16, pad=(1,1), relu),
-            MaxPool((2,2)),
-            Conv((3, 3), 16=>32, pad=(1,1), relu),
-            MaxPool((2,2)),
-            Conv((3, 3), 32=>32, pad=(1,1), relu),
-            MaxPool((2,2)),
-            flatten,
-            Dense(prod(cnn_output_size), n_out))
-    end
+    return Chain(
+        Conv((3, 3), n_channels=>16, pad=(1,1), relu),
+        MaxPool((2,2)),
+        Conv((3, 3), 16=>32, pad=(1,1), relu),
+        MaxPool((2,2)),
+        Conv((3, 3), 32=>32, pad=(1,1), relu),
+        MaxPool((2,2)),
+        flatten,
+        Dense(prod(cnn_output_size), n_out))
+end
+
+@testset_accelerated "Image MNIST" accel begin
 
     model = MLJFlux.ImageClassifier(builder=MyConvBuilder())
 
@@ -80,18 +89,22 @@ mutable struct MyConvBuilder <: MLJFlux.Builder end
 
 end
 
-@testset "ColorImages" begin
 
-    builder = mynn((2,2), (2,2))
+## BASIC IMAGE TESTS COLOR
+
+builder = mynn((2,2), (2,2))
+
+# collection of color images as a 4D array in WHCN format:
+raw_images = rand(Float32, 6, 6, 3, 50);
+
+images = coerce(raw_images, ColorImage);
+@test scitype(images) == AbstractVector{ColorImage{6,6}}
+
+labels = categorical(rand(1:5, 50));
+
+@testset_accelerated "ColorImages" accel begin
+
     model = MLJFlux.ImageClassifier(builder=builder, epochs=10)
-
-    # collection of color images as a 4D array in WHCN format:
-    raw_images = rand(6, 6, 3, 50);
-
-    images = coerce(raw_images, ColorImage);
-    @test scitype(images) == AbstractVector{ColorImage{6,6}}
-
-    labels = categorical(rand(1:5, 50));
 
     fitresult, cache, report = MLJBase.fit(model, 3, images, labels)
 
@@ -108,7 +121,7 @@ end
 
     # tests update logic, etc (see test_utililites.jl):
     @test basictest(MLJFlux.ImageClassifier, images, labels,
-                           model.builder, model.optimiser, 0.95)
+                           model.builder, model.optimiser, 0.95, accel)
 end
 
 true

--- a/test/regressor.jl
+++ b/test/regressor.jl
@@ -20,7 +20,7 @@ optimiser = Flux.Optimise.ADAM()
     # test a bit better than constant predictor
     model = MLJFlux.NeuralNetworkRegressor(acceleration=accel)
     train, test = MLJBase.partition(1:N, 0.7)
-    mach = fit!(machine(model, X, y), rows=train, verbosity=0)
+    @time mach = fit!(machine(model, X, y), rows=train, verbosity=0)
     yhat = predict(mach, rows=test)
     truth = y[test]
     goal =0.8*model.loss(truth .- mean(truth), 0)
@@ -42,7 +42,7 @@ end
     # test a bit better than constant predictor
     model = MLJFlux.MultitargetNeuralNetworkRegressor(acceleration=accel)
     train, test = MLJBase.partition(1:N, 0.7)
-    mach = fit!(machine(model, X, y), rows=train, verbosity=0)
+    @test mach = fit!(machine(model, X, y), rows=train, verbosity=2)
     yhat = predict(mach, rows=test)
     truth = ymatrix[test]
     goal =0.8*model.loss(truth .- mean(truth), 0)

--- a/test/regressor.jl
+++ b/test/regressor.jl
@@ -1,4 +1,3 @@
-
 Random.seed!(123)
 
 N = 200

--- a/test/regressor.jl
+++ b/test/regressor.jl
@@ -6,12 +6,18 @@ X = MLJBase.table(randn(Float32, N, 5));
 builder = MLJFlux.Short(σ=identity)
 optimiser = Flux.Optimise.ADAM()
 
-@testset "NeuralNetworkRegressor" begin
+@testset_accelerated "NeuralNetworkRegressor" accel begin
     y = 1 .+ X.x1 - X.x2 .- 2X.x4 + X.x5
-    basictest(MLJFlux.NeuralNetworkRegressor, X, y, builder, optimiser, 0.7)
+    basictest(MLJFlux.NeuralNetworkRegressor,
+              X,
+              y,
+              builder,
+              optimiser,
+              0.7,
+              accel)
 
     # test a bit better than constant predictor
-    model = MLJFlux.NeuralNetworkRegressor()
+    model = MLJFlux.NeuralNetworkRegressor(acceleration=accel)
     train, test = MLJBase.partition(1:N, 0.7)
     mach = fit!(machine(model, X, y), rows=train, verbosity=0)
     yhat = predict(mach, rows=test)
@@ -20,7 +26,7 @@ optimiser = Flux.Optimise.ADAM()
     @test model.loss(yhat, truth) < goal
 end
 
-@testset "MultitargetNeuralNetworkRegressor" begin
+@testset_accelerated "MultitargetNeuralNetworkRegressor" accel begin
     ymatrix = hcat(1 .+ X.x1 - X.x2, 1 .- 2X.x4 + X.x5);
     y = MLJBase.table(ymatrix);
     basictest(MLJFlux.MultitargetNeuralNetworkRegressor,
@@ -28,10 +34,11 @@ end
               y,
               builder,
               optimiser,
-              0.8)
+              0.8,
+              accel)
 
     # test a bit better than constant predictor
-    model = MLJFlux.MultitargetNeuralNetworkRegressor()
+    model = MLJFlux.MultitargetNeuralNetworkRegressor(acceleration=accel)
     train, test = MLJBase.partition(1:N, 0.7)
     mach = fit!(machine(model, X, y), rows=train, verbosity=0)
     yhat = predict(mach, rows=test)

--- a/test/regressor.jl
+++ b/test/regressor.jl
@@ -7,6 +7,7 @@ builder = MLJFlux.Short(σ=identity)
 optimiser = Flux.Optimise.ADAM()
 
 @testset_accelerated "NeuralNetworkRegressor" accel begin
+    Random.seed!(123)
     y = 1 .+ X.x1 - X.x2 .- 2X.x4 + X.x5
     basictest(MLJFlux.NeuralNetworkRegressor,
               X,
@@ -27,6 +28,7 @@ optimiser = Flux.Optimise.ADAM()
 end
 
 @testset_accelerated "MultitargetNeuralNetworkRegressor" accel begin
+    Random.seed!(123)
     ymatrix = hcat(1 .+ X.x1 - X.x2, 1 .- 2X.x4 + X.x5);
     y = MLJBase.table(ymatrix);
     basictest(MLJFlux.MultitargetNeuralNetworkRegressor,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,12 @@ using Statistics
 import StatsBase
 using MLJModelInterface.ScientificTypes
 
+using ComputationalResources
+using ComputationalResources: CPU1, CUDALibs
+
+const RESOURCES = Any[CPU1(), CUDALibs()]
+const EXCLUDED_RESOURCE_TYPES = Any[CUDALibs,]
+
 seed!(123)
 
 include("test_utils.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,8 +19,8 @@ EXCLUDED_RESOURCE_TYPES = Any[]
 
 MLJFlux.gpu_isdead() && push!(EXCLUDED_RESOURCE_TYPES, CUDALibs)
 
-@show RESOURCES
-@show EXCLUDED_RESOURCE_TYPES
+@info "Available computational resources: $RESOURCES"
+@info "Current test run to exclude resources with these types: $EXCLUDED_RESOURCE_TYPES"
 
 # alternative version of Short builder with no dropout; see
 # https://github.com/FluxML/Flux.jl/issues/1372

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,8 +14,10 @@ using MLJModelInterface.ScientificTypes
 using ComputationalResources
 using ComputationalResources: CPU1, CUDALibs
 
-const RESOURCES = Any[CPU1(), CUDALibs()]
-const EXCLUDED_RESOURCE_TYPES = Any[CUDALibs,]
+const RESOURCES = Any[CUDALibs(), CPU1()]
+# const RESOURCES = Any[CPU1(), CUDALibs()]
+const EXCLUDED_RESOURCE_TYPES = Any[]
+# const EXCLUDED_RESOURCE_TYPES = Any[CUDALibs,]
 
 seed!(123)
 
@@ -25,9 +27,9 @@ include("test_utils.jl")
     include("core.jl")
 end
 
-@testset "regressor" begin
-    include("regressor.jl")
-end
+# @testset "regressor" begin
+#     include("regressor.jl")
+# end
 
 @testset "classifier" begin
     include("classifier.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,9 +17,7 @@ using ComputationalResources: CPU1, CUDALibs
 const RESOURCES = Any[CPU1(), CUDALibs()]
 EXCLUDED_RESOURCE_TYPES = Any[]
 
-if Flux.gpu(rand(2,2)) isa Array
-    push!(EXCLUDED_RESOURCE_TYPES, CUDALibs)
-end
+MLJFlux.gpu_isdead() && push!(EXCLUDED_RESOURCE_TYPES, CUDALibs)
 
 @show RESOURCES
 @show EXCLUDED_RESOURCE_TYPES
@@ -44,6 +42,10 @@ include("test_utils.jl")
 
 @testset "core" begin
     include("core.jl")
+end
+
+@testset "common" begin
+    include("common.jl")
 end
 
 @testset "regressor" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,9 +15,14 @@ using ComputationalResources
 using ComputationalResources: CPU1, CUDALibs
 
 const RESOURCES = Any[CPU1(), CUDALibs()]
-# const RESOURCES = Any[CPU1(), CUDALibs()]
-const EXCLUDED_RESOURCE_TYPES = Any[]
-# const EXCLUDED_RESOURCE_TYPES = Any[CUDALibs,]
+EXCLUDED_RESOURCE_TYPES = Any[]
+
+if Flux.gpu(rand(2,2)) isa Array
+    push!(EXCLUDED_RESOURCE_TYPES, CUDALibs)
+end
+
+@show RESOURCES
+@show EXCLUDED_RESOURCE_TYPES
 
 # alternative version of Short builder with no dropout; see
 # https://github.com/FluxML/Flux.jl/issues/1372

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,10 +14,24 @@ using MLJModelInterface.ScientificTypes
 using ComputationalResources
 using ComputationalResources: CPU1, CUDALibs
 
-const RESOURCES = Any[CUDALibs(), CPU1()]
+const RESOURCES = Any[CPU1(), CUDALibs()]
 # const RESOURCES = Any[CPU1(), CUDALibs()]
 const EXCLUDED_RESOURCE_TYPES = Any[]
 # const EXCLUDED_RESOURCE_TYPES = Any[CUDALibs,]
+
+# alternative version of Short builder with no dropout; see
+# https://github.com/FluxML/Flux.jl/issues/1372
+mutable struct Short2 <: MLJFlux.Builder
+    n_hidden::Int     # if zero use geometric mean of input/output
+    σ
+end
+Short2(; n_hidden=0, σ=Flux.sigmoid) = Short2(n_hidden, σ)
+function MLJFlux.build(builder::Short2, n, m)
+    n_hidden =
+        builder.n_hidden == 0 ? round(Int, sqrt(n*m)) : builder.n_hidden
+    return Flux.Chain(Flux.Dense(n, n_hidden, builder.σ),
+                       Flux.Dense(n_hidden, m))
+end
 
 seed!(123)
 
@@ -27,9 +41,9 @@ include("test_utils.jl")
     include("core.jl")
 end
 
-# @testset "regressor" begin
-#     include("regressor.jl")
-# end
+@testset "regressor" begin
+    include("regressor.jl")
+end
 
 @testset "classifier" begin
     include("classifier.jl")

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -50,6 +50,7 @@ function basictest(ModelType, X, y, builder, optimiser, threshold, accel)
     ModelType_str = string(ModelType)
     ModelType_ex = Meta.parse(ModelType_str)
     accel_ex = Meta.parse(string(accel))
+    optimiser = deepcopy(optimiser)
 
     eval(quote
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -4,6 +4,9 @@ end
 macro testset_accelerated(name::String, var, opts::Expr, ex)
     testset_accelerated(name, var, ex; eval(opts)...)
 end
+
+# To exclude a resource, say, CPU1, do like
+# `@test_accelerated "cool test" accel (exclude=[CPU1,],) begin ... end`
 function testset_accelerated(name::String, var, ex; exclude=[])
 
     final_ex = quote end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -9,6 +9,8 @@ end
 # `@test_accelerated "cool test" accel (exclude=[CPU1,],) begin ... end`
 function testset_accelerated(name::String, var, ex; exclude=[])
 
+    @info "Starting this test: $name..."
+    
     final_ex = quote end
 
     append!(exclude, EXCLUDED_RESOURCE_TYPES)
@@ -34,7 +36,7 @@ end
 
 # To run a battery of tests checking: (i) fit, predict & update calls
 # work; (ii) update logic is correct; (iii) training loss after 10
-# epochs is 80% or better than initial loss:
+# epochs is better than `threshold` times initial loss:
 function basictest(ModelType, X, y, builder, optimiser, threshold, accel)
 
     ModelType_str = string(ModelType)
@@ -77,7 +79,9 @@ function basictest(ModelType, X, y, builder, optimiser, threshold, accel)
                                optimiser=$optimiser,
                                epochs=2,
                                acceleration=$accel_ex)
-         fitresult, cache, report = MLJBase.fit(model, 0, $X, $y);
+         println()
+         fitresult, cache, report = MLJBase.fit(model, 1, $X, $y);
+         println()
 
          # change batch_size and check it performs cold restart:
          model.batch_size = 2


### PR DESCRIPTION
This is a continuation of #63 for adding GPU support but which limits movement of input data between the cpu and gpu in favour of moving the learned parameters (Flux chain). I believe it renders #64 redundant, as the fall-back serialisation methods `save` and `restore` ought to suffice. 

It includes complete tests for the GPU case, including test that GPU and CPU have approximately same behaviour. When testing on a CPU, tests for GPU are automatically suppressed. 





