### PR TITLE
Add L2/L1 regularization

### DIFF
--- a/src/MLJFlux.jl
+++ b/src/MLJFlux.jl
@@ -14,6 +14,7 @@ using ColorTypes
 using ComputationalResources
 using Random
 
+include("penalized_losses.jl")
 include("core.jl")
 include("builders.jl")
 include("types.jl")

--- a/src/penalized_losses.jl
+++ b/src/penalized_losses.jl
@@ -1,0 +1,62 @@
+# Note (1). See
+# https://discourse.julialang.org/t/weight-regularisation-which-iterates-params-m-in-flux-mutating-arrays-is-not-supported/64314
+
+
+""" Penalizer(λ, α)
+
+Returns a callable object `penalizer` for evaluating regularization
+penalties associated with some numerically array. Specifically,
+`penalizer(A)` returns
+
+   λ*(α*L1 + (1 - α)*L2),
+
+where `L1` is the sum of absolute values of the elments of `A` and
+`L2` is the sum of squares of those elements.
+"""
+struct Penalizer{T}
+    lambda::T
+    alpha::T
+    function Penalizer(lambda, alpha)
+        lambda == 0 && return new{Nothing}(nothing, nothing)
+        T = promote_type(typeof.((lambda, alpha))...)
+        return new{T}(lambda, alpha)
+    end
+end
+
+(::Penalizer{Nothing})(::Any) = 0
+function (p::Penalizer)(A)
+    λ = p.lambda
+    α = p.alpha
+    # avoiding broadcasting; see Note (1) above
+    L2 = sum(x^2 for x in A)
+    L1 = sum(abs(x) for x in A)
+    return  λ*(α*L1 + (1 - α)*L2)
+end
+
+"""
+    PenalizedLoss(model, chain)
+
+Returns a callable object `p`, for returning the penalized loss on
+some batch of data `(x, y)`. Specifically, `p(x, y)` returns
+
+   loss(chain(x), y) + sum(Penalizer(λ, α).(params(chain)))
+
+where `loss = model.loss`, `α = model.alpha`, `λ = model.lambda`.
+
+See also [`Penalizer`](@ref)
+
+"""
+struct PenalizedLoss
+    loss
+    penalizer
+    chain
+    params
+    function PenalizedLoss(model, chain)
+        loss = model.loss
+        penalizer = Penalizer(model.lambda, model.alpha)
+        params = Flux.params(chain)
+        return new(loss, penalizer, chain, params)
+    end
+end
+(p::PenalizedLoss)(x, y) = p.loss(p.chain(x), y) +
+    sum(p.penalizer(θ) for θ in p.params)

--- a/src/penalized_losses.jl
+++ b/src/penalized_losses.jl
@@ -46,17 +46,18 @@ where `loss = model.loss`, `α = model.alpha`, `λ = model.lambda`.
 See also [`Penalizer`](@ref)
 
 """
-struct PenalizedLoss
+struct PenalizedLoss{P}
     loss
-    penalizer
+    penalizer::P
     chain
     params
     function PenalizedLoss(model, chain)
         loss = model.loss
         penalizer = Penalizer(model.lambda, model.alpha)
         params = Flux.params(chain)
-        return new(loss, penalizer, chain, params)
+        return new{typeof(penalizer)}(loss, penalizer, chain, params)
     end
 end
+(p::PenalizedLoss{Penalizer{Nothing}})(x, y) = p.loss(p.chain(x), y)
 (p::PenalizedLoss)(x, y) = p.loss(p.chain(x), y) +
     sum(p.penalizer(θ) for θ in p.params)

--- a/src/penalized_losses.jl
+++ b/src/penalized_losses.jl
@@ -5,7 +5,7 @@
 """ Penalizer(λ, α)
 
 Returns a callable object `penalizer` for evaluating regularization
-penalties associated with some numerically array. Specifically,
+penalties associated with some numerical array. Specifically,
 `penalizer(A)` returns
 
    λ*(α*L1 + (1 - α)*L2),

--- a/src/penalized_losses.jl
+++ b/src/penalized_losses.jl
@@ -28,8 +28,8 @@ function (p::Penalizer)(A)
     λ = p.lambda
     α = p.alpha
     # avoiding broadcasting; see Note (1) above
-    L2 = sum(x^2 for x in A)
-    L1 = sum(abs(x) for x in A)
+    L2 = sum(abs2, A)
+    L1 = sum(abs,  A)
     return  λ*(α*L1 + (1 - α)*L2)
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -3,6 +3,51 @@ abstract type MLJFluxDeterministic <: MLJModelInterface.Deterministic end
 
 const MLJFluxModel = Union{MLJFluxProbabilistic,MLJFluxDeterministic}
 
+const doc_regressor(model_name) = """
+
+    $model_name(; hyparameters...)
+
+Instantiate an MLJFlux model. Available hyperparameters:
+
+- `builder`: Default = `MLJFlux.Linear(σ=Flux.relu)` (regressors) or
+   `MLJFlux.Short(n_hidden=0, dropout=0.5, σ=Flux.σ)` (classifiers)
+
+-  `optimiser`: The optimiser to use for training. Default =
+   `Flux.ADAM()`
+
+- `loss`: The loss function used for training. Default = `Flux.mse`
+   (regressors) and `Flux.crossentropy` (classifiers)
+
+- `n_epochs`: Number of epochs to train for. Default = `10`
+
+-  `batch_size`: The batch_size for the data. Default = 1
+
+-  `lambda`: The regularization strength. Default = 0. Range = [0, ∞)
+
+- `alpha`: The L2/L1 mix of regularization. Default = 0. Range = [0, 1]
+
+-  `rng`: The random number generator (RNG) passed to builders, for
+   weight intitialization, for example. Can be any `AbstractRNG` or
+   the seed (integer) for a `MersenneTwister` that is reset on every
+   cold restart of model (machine) training. Default =
+   `GLOBAL_RNG`.
+
+-  `acceleration`: Use `CUDALibs()` for training on GPU; default is `CPU1()`.
+
+- `optimiser_changes_trigger_retraining`: True if fitting an
+   associated machine should trigger retraining from scratch whenever
+   the optimiser changes. Default = `false`
+
+"""
+
+doc_classifier(model_name) = doc_regressor(model_name)*"""
+- `finaliser`: Operation applied to the unnormalized output of the
+  final layer to obtain probabilities (outputs summing to
+  one). The shape of the inputs and outputs
+  of this operator must match.  Default = `Flux.softmax`.
+
+"""
+
 for Model in [:NeuralNetworkClassifier, :ImageClassifier]
 
     ex = quote
@@ -51,6 +96,9 @@ for Model in [:NeuralNetworkClassifier, :ImageClassifier]
 
             return model
         end
+
+        @doc doc_classifier($Model) $Model
+
     end
     eval(ex)
 
@@ -100,6 +148,9 @@ for Model in [:NeuralNetworkRegressor, :MultitargetNeuralNetworkRegressor]
 
             return model
         end
+
+        @doc $doc_regressor($Model) $Model
+
     end
     eval(ex)
 

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -1,0 +1,26 @@
+rng = StableRNGs.StableRNG(123)
+
+table = load_iris()
+y, X = unpack(table, ==(:target), _->true, rng=rng)
+
+@testset_accelerated "regularization has an effect" accel begin
+
+    model = NeuralNetworkClassifier(acceleration=accel,
+                                    builder=MLJFlux.Linear(),
+                                    rng=rng)
+    model2 = deepcopy(model)
+    model3 = deepcopy(model)
+    model3.lambda = 0.1
+
+    e = evaluate(model, X, y, resampling=Holdout(), measure=LogLoss())
+    loss1 = e.measurement[1]
+
+    e = evaluate(model2, X, y, resampling=Holdout(), measure=LogLoss())
+    loss2 = e.measurement[1]
+
+    e = evaluate(model3, X, y, resampling=Holdout(), measure=LogLoss())
+    loss3 = e.measurement[1]
+
+    @test loss1 ≈ loss2
+    @test !(loss2 ≈ loss3)
+end

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -5,7 +5,7 @@ y, X = unpack(table, ==(:target), _->true, rng=rng)
 
 @testset_accelerated "regularization has an effect" accel begin
 
-    model = NeuralNetworkClassifier(acceleration=accel,
+    model = MLJFlux.NeuralNetworkClassifier(acceleration=accel,
                                     builder=MLJFlux.Linear(),
                                     rng=rng)
     model2 = deepcopy(model)

--- a/test/penalized_losses.jl
+++ b/test/penalized_losses.jl
@@ -1,0 +1,39 @@
+using Statistics
+
+@testset  "penalties" begin
+    A = [-1 2; -3 4]
+    lambda = 1
+
+    # 100% L2:
+    alpha = 0
+    penalty = MLJFlux.Penalizer(lambda, alpha)
+    @test penalty(A) ≈ 1 + 4 + 9 + 16
+
+    # 100% L1:
+    alpha = 1
+    penalty = MLJFlux.Penalizer(lambda, alpha)
+    @test penalty(A) ≈ 1 + 2 + 3 + 4
+
+    # no strength:
+    lambda = 0
+    alpha = 42.324
+    penalty = MLJFlux.Penalizer(lambda, alpha)
+    @test penalty(A) == 0
+end
+
+@testset "penalized_losses" begin
+    # construct a penalized loss function:
+    model = MLJFlux.NeuralNetworkRegressor(lambda=1, alpha=1, loss=Flux.mae)
+    chain = Flux.Dense(3, 1, identity)
+    p = MLJFlux.PenalizedLoss(model, chain)
+
+    # construct a batch:
+    b = 5
+    x = rand(Float32, 3, b)
+    y = rand(Float32, 1, b)
+
+    # compare loss by hand and with penalized loss function:
+    penalty = (sum(abs.(chain.weight)) + abs(chain.bias[1]))
+    yhat = chain(x)
+    @test p(x, y) ≈ Flux.mae(yhat, y) + penalty
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,3 +72,6 @@ end
     include("image.jl")
 end
 
+@testset "integration" begin
+    include("integration.jl")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,10 @@ seed!(123)
 
 include("test_utils.jl")
 
+@testset "penalized_losses" begin
+    include("penalized_losses.jl")
+end
+
 @testset "core" begin
     include("core.jl")
 end


### PR DESCRIPTION
This PR:

- resolves #169 
- moves responsibility for CPU <--> GPU data movement to the fit/update methods. Previously, this was done in the `fit!` method. This change was natural in addressing above and anticipates further transfer of responsibility to planned data front-end (see https://alan-turing-institute.github.io/MLJ.jl/dev/adding_models_for_general_use/#Implementing-a-data-front-end and #97).
- adds missing doc-strings to all the models

@ToucheSir Further to [Julia Discourse discussion](https://discourse.julialang.org/t/weight-regularisation-which-iterates-params-m-in-flux-mutating-arrays-is-not-supported/64314/5), no change was actually necessary to the [core`train!` loop](https://github.com/FluxML/MLJFlux.jl/blob/8f09ab1665e32e991e97ed2b2e67189a091ecdc4/src/core.jl#L39) to add regularization. It's just that the loss function passed to this loop now depends on the `chain` (Flux model), when L2/L1 regularisation parameters are non-trivial. To avoid the array mutation error I needed to avoid broadcasting in the computation of the penalty [here](https://github.com/FluxML/MLJFlux.jl/blob/8f09ab1665e32e991e97ed2b2e67189a091ecdc4/src/penalized_losses.jl#L31). Any performance suggestions re these two bits of code appreciated.