### PR TITLE
Rethrow the error caught when builder fails

### DIFF
--- a/src/mlj_model_interface.jl
+++ b/src/mlj_model_interface.jl
@@ -59,7 +59,7 @@ function MLJModelInterface.fit(model::MLJFluxModel,
         build(model, rng, shape) |> move
     catch ex
         @error ERR_BUILDER
-        throw(ex)
+        rethrow()
     end
 
     penalty = Penalty(model)

--- a/src/mlj_model_interface.jl
+++ b/src/mlj_model_interface.jl
@@ -59,6 +59,7 @@ function MLJModelInterface.fit(model::MLJFluxModel,
         build(model, rng, shape) |> move
     catch ex
         @error ERR_BUILDER
+        throw(ex)
     end
 
     penalty = Penalty(model)


### PR DESCRIPTION
Closes #237

There is presently a `throw`-`catch` block to check a user-provided builder will successfully create a Flux model. This PR ensures that the exception causing the fail is ultimately thrown. 